### PR TITLE
[PRD-3794] Split init access control to several instructions

### DIFF
--- a/app/src/idl/transfer_restrictions.ts
+++ b/app/src/idl/transfer_restrictions.ts
@@ -279,7 +279,40 @@ export type TransferRestrictions = {
           }
         },
         {
-          "name": "authorityWalletRole",
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "tokenProgram",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "initializeAccessControlArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initializeDeployerRole",
+      "discriminator": [
+        20,
+        92,
+        210,
+        30,
+        61,
+        126,
+        220,
+        36
+      ],
+      "accounts": [
+        {
+          "name": "walletRole",
           "writable": true,
           "pda": {
             "seeds": [
@@ -301,15 +334,62 @@ export type TransferRestrictions = {
               },
               {
                 "kind": "account",
-                "path": "mint"
+                "path": "securityToken"
               },
               {
                 "kind": "account",
-                "path": "authority"
+                "path": "payer"
               }
             ]
           }
         },
+        {
+          "name": "accessControl",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  99
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "securityToken"
+              }
+            ]
+          }
+        },
+        {
+          "name": "securityToken"
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initializeExtraAccountMetaList",
+      "discriminator": [
+        92,
+        197,
+        174,
+        197,
+        41,
+        124,
+        19,
+        3
+      ],
+      "accounts": [
         {
           "name": "extraMetasAccount",
           "writable": true,
@@ -341,30 +421,74 @@ export type TransferRestrictions = {
               },
               {
                 "kind": "account",
-                "path": "mint"
+                "path": "securityMint"
               }
             ]
           }
         },
         {
-          "name": "systemProgram",
-          "address": "11111111111111111111111111111111"
+          "name": "securityMint"
         },
         {
-          "name": "tokenProgram",
-          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+          "name": "authorityWalletRole",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  119,
+                  97,
+                  108,
+                  108,
+                  101,
+                  116,
+                  95,
+                  114,
+                  111,
+                  108,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "securityMint"
+              },
+              {
+                "kind": "account",
+                "path": "payer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "accessControl",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  99
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "securityMint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
         }
       ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "initializeAccessControlArgs"
-            }
-          }
-        }
-      ]
+      "args": []
     },
     {
       "name": "initializeSecurityAssociatedAccount",
@@ -1237,6 +1361,16 @@ export type TransferRestrictions = {
       "code": 6002,
       "name": "transferRuleLocked",
       "msg": "Transfer rule locked"
+    },
+    {
+      "code": 6003,
+      "name": "invalidAuthority",
+      "msg": "Invalid authority"
+    },
+    {
+      "code": 6004,
+      "name": "invalidRole",
+      "msg": "Invalid role"
     }
   ],
   "types": [
@@ -1247,6 +1381,10 @@ export type TransferRestrictions = {
         "fields": [
           {
             "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
             "type": "pubkey"
           }
         ]
@@ -1274,10 +1412,8 @@ export type TransferRestrictions = {
             "type": "string"
           },
           {
-            "name": "delegate",
-            "type": {
-              "option": "pubkey"
-            }
+            "name": "authority",
+            "type": "pubkey"
           }
         ]
       }

--- a/programs/transfer-restrictions/src/contexts/initialize_deployer_role.rs
+++ b/programs/transfer-restrictions/src/contexts/initialize_deployer_role.rs
@@ -1,0 +1,36 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token_interface::Mint;
+
+use crate::{
+    contexts::common::DISCRIMINATOR_LEN, AccessControl, WalletRole, ACCESS_CONTROL_SEED,
+    WALLET_ROLE_PREFIX,
+};
+
+#[derive(Accounts)]
+#[instruction()]
+pub struct InitializeDeployerRole<'info> {
+    #[account(init, payer = payer, space = DISCRIMINATOR_LEN + WalletRole::INIT_SPACE,
+      seeds = [
+        WALLET_ROLE_PREFIX,
+        &security_token.key().to_bytes(),
+        &payer.key().to_bytes(),
+      ],
+      bump,
+    )]
+    pub wallet_role: Account<'info, WalletRole>,
+    #[account(mut,
+      seeds = [
+        ACCESS_CONTROL_SEED,
+        security_token.key().as_ref(),
+      ],
+      bump,
+    )]
+    pub access_control: Account<'info, AccessControl>,
+    pub security_token: Box<InterfaceAccount<'info, Mint>>,
+
+    #[account(mut,
+      constraint = payer.key() == access_control.authority,
+    )]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}

--- a/programs/transfer-restrictions/src/contexts/initialize_extra_meta_list.rs
+++ b/programs/transfer-restrictions/src/contexts/initialize_extra_meta_list.rs
@@ -1,0 +1,54 @@
+use crate::{get_meta_list_size, AccessControl, WalletRole, ACCESS_CONTROL_SEED, WALLET_ROLE_PREFIX};
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    token_2022::ID as TOKEN_2022_PROGRAM_ID,
+    token_interface::Mint,
+};
+
+pub const META_LIST_ACCOUNT_SEED: &[u8] = b"extra-account-metas";
+
+#[derive(Accounts)]
+pub struct InitializeExtraAccountMetaList<'info> {
+    #[account(
+      init,
+      space = get_meta_list_size()?,
+      seeds = [
+        META_LIST_ACCOUNT_SEED,
+        security_mint.key().as_ref(),
+      ],
+      bump,
+      payer = payer,
+    )]
+    /// CHECK: extra metas account
+    pub extra_metas_account: UncheckedAccount<'info>,
+
+    #[account(
+        mint::token_program = TOKEN_2022_PROGRAM_ID,
+    )]
+    pub security_mint: Box<InterfaceAccount<'info, Mint>>,
+
+    #[account(
+      seeds = [
+        WALLET_ROLE_PREFIX,
+        &security_mint.key().to_bytes(),
+        &payer.key().to_bytes(),
+      ],
+      bump,
+    )]
+    pub authority_wallet_role: Account<'info, WalletRole>,
+
+    #[account(
+      constraint = security_mint.key() == access_control.mint,
+      seeds = [
+        ACCESS_CONTROL_SEED,
+        security_mint.key().as_ref(),
+      ],
+      bump,
+    )]
+    pub access_control: Box<Account<'info, AccessControl>>,
+    
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+}

--- a/programs/transfer-restrictions/src/contexts/mod.rs
+++ b/programs/transfer-restrictions/src/contexts/mod.rs
@@ -35,3 +35,9 @@ pub use mint_securities::*;
 
 pub mod burn_securities;
 pub use burn_securities::*;
+
+pub mod initialize_extra_meta_list;
+pub use initialize_extra_meta_list::*;
+
+pub mod initialize_deployer_role;
+pub use initialize_deployer_role::*;

--- a/programs/transfer-restrictions/src/errors.rs
+++ b/programs/transfer-restrictions/src/errors.rs
@@ -8,4 +8,8 @@ pub enum SolanaSecurityTokenError {
     Unauthorized,
     #[msg("Transfer rule locked")]
     TransferRuleLocked,
+    #[msg("Invalid authority")]
+    InvalidAuthority,
+    #[msg("Invalid role")]
+    InvalidRole,
 }

--- a/programs/transfer-restrictions/src/instructions/access_control/initialize.rs
+++ b/programs/transfer-restrictions/src/instructions/access_control/initialize.rs
@@ -1,40 +1,32 @@
 use crate::{
-    contexts::InitializeAccessControl, get_extra_account_metas,
-    update_account_lamports_to_minimum_balance, InitializeAccessControlArgs, Roles,
+    contexts::InitializeAccessControl, errors::SolanaSecurityTokenError, update_account_lamports_to_minimum_balance, InitializeAccessControlArgs
 };
 use anchor_lang::prelude::*;
-use spl_tlv_account_resolution::state::ExtraAccountMetaList;
-use spl_transfer_hook_interface::instruction::ExecuteInstruction;
 
 pub fn initialize(
     ctx: Context<InitializeAccessControl>,
     args: InitializeAccessControlArgs,
 ) -> Result<()> {
+    if args.authority != ctx.accounts.authority.key() {
+        return Err(SolanaSecurityTokenError::InvalidAuthority.into());
+    }
     let access_control = &mut ctx.accounts.access_control;
     access_control.mint = *ctx.accounts.mint.to_account_info().key;
+    access_control.authority = *ctx.accounts.authority.to_account_info().key;
 
-    // initialize the extra metas account
-    let extra_metas_account = &ctx.accounts.extra_metas_account;
-    let metas = get_extra_account_metas()?;
-    let mut data = extra_metas_account.try_borrow_mut_data()?;
-    ExtraAccountMetaList::init::<ExecuteInstruction>(&mut data, &metas)?;
-
-    // // TODO: initialize token metadata separately
-    // ctx.accounts
-    //     .initialize_token_metadata(
-    //         args.name,
-    //         args.symbol,
-    //         args.uri,
-    //     )?;
+    ctx.accounts
+        .initialize_token_metadata(
+            ctx.program_id,
+            args.name,
+            args.symbol,
+            args.uri,
+        )?;
 
     update_account_lamports_to_minimum_balance(
         ctx.accounts.mint.to_account_info(),
         ctx.accounts.payer.to_account_info(),
         ctx.accounts.system_program.to_account_info(),
     )?;
-
-    let wallet_role = &mut ctx.accounts.authority_wallet_role;
-    wallet_role.role = Roles::All as u8;
 
     Ok(())
 }

--- a/programs/transfer-restrictions/src/instructions/access_control/initialize_deployer_role.rs
+++ b/programs/transfer-restrictions/src/instructions/access_control/initialize_deployer_role.rs
@@ -1,0 +1,9 @@
+use crate::{contexts::InitializeDeployerRole, Roles};
+use anchor_lang::prelude::*;
+
+pub fn initialize_deployer_role(ctx: Context<InitializeDeployerRole>) -> Result<()> {
+    let wallet_role = &mut ctx.accounts.wallet_role;
+    wallet_role.role = Roles::ContractAdmin as u8;
+
+    Ok(())
+}

--- a/programs/transfer-restrictions/src/instructions/access_control/initialize_extra_meta_list.rs
+++ b/programs/transfer-restrictions/src/instructions/access_control/initialize_extra_meta_list.rs
@@ -1,0 +1,19 @@
+use crate::{
+    contexts::InitializeExtraAccountMetaList, errors::SolanaSecurityTokenError, get_extra_account_metas, Roles
+};
+use anchor_lang::prelude::*;
+use spl_tlv_account_resolution::state::ExtraAccountMetaList;
+use spl_transfer_hook_interface::instruction::ExecuteInstruction;
+
+pub fn initialize_extra_account_meta_list(ctx: Context<InitializeExtraAccountMetaList>) -> Result<()> {
+    if !ctx.accounts.authority_wallet_role.has_role(Roles::ContractAdmin) {
+        return Err(SolanaSecurityTokenError::Unauthorized.into());
+    }
+
+    let extra_metas_account = &ctx.accounts.extra_metas_account;
+    let metas = get_extra_account_metas()?;
+    let mut data = extra_metas_account.try_borrow_mut_data()?;
+    ExtraAccountMetaList::init::<ExecuteInstruction>(&mut data, &metas)?;
+
+    Ok(())
+}

--- a/programs/transfer-restrictions/src/instructions/access_control/mod.rs
+++ b/programs/transfer-restrictions/src/instructions/access_control/mod.rs
@@ -15,3 +15,9 @@ pub use mint_securities::*;
 
 pub mod burn_securities;
 pub use burn_securities::*;
+
+pub mod initialize_extra_meta_list;
+pub use initialize_extra_meta_list::*;
+
+pub mod initialize_deployer_role;
+pub use initialize_deployer_role::*;

--- a/programs/transfer-restrictions/src/instructions/access_control/update_wallet_role.rs
+++ b/programs/transfer-restrictions/src/instructions/access_control/update_wallet_role.rs
@@ -9,9 +9,12 @@ pub fn update_wallet_role(ctx: Context<UpdateWalletRole>, role: u8) -> Result<()
   if !ctx.accounts.authority_wallet_role.has_role(Roles::ContractAdmin) {
     return Err(SolanaSecurityTokenError::Unauthorized.into());
   }
+  if role > Roles::All as u8 {
+    return Err(SolanaSecurityTokenError::InvalidRole.into());
+  }
 
-  let security_associated_account = &mut ctx.accounts.wallet_role;
-  security_associated_account.role = role;
+  let wallet_role = &mut ctx.accounts.wallet_role;
+  wallet_role.role = role;
 
   Ok(())
 }

--- a/programs/transfer-restrictions/src/lib.rs
+++ b/programs/transfer-restrictions/src/lib.rs
@@ -21,6 +21,10 @@ pub mod transfer_restrictions {
         instructions::access_control::initialize(ctx, args)
     }
 
+    pub fn initialize_deployer_role(ctx: Context<InitializeDeployerRole>) -> Result<()> {
+        instructions::access_control::initialize_deployer_role(ctx)
+    }
+
     pub fn initialize_wallet_role(ctx: Context<InitializeWalletRole>, role: u8) -> Result<()> {
         instructions::access_control::initialize_wallet_role(ctx, role)
     }
@@ -33,6 +37,12 @@ pub mod transfer_restrictions {
     #[interface(spl_transfer_hook_interface::execute)]
     pub fn execute_transaction(ctx: Context<ExecuteTransferHook>, amount: u64) -> Result<()> {
         instructions::access_control::handler(ctx, amount)
+    }
+
+    pub fn initialize_extra_account_meta_list(
+        ctx: Context<InitializeExtraAccountMetaList>,
+    ) -> Result<()> {
+        instructions::access_control::initialize_extra_account_meta_list(ctx)
     }
 
     pub fn mint_securities(ctx: Context<MintSecurities>, amount: u64) -> Result<()> {

--- a/tests/solana-security-token.ts
+++ b/tests/solana-security-token.ts
@@ -7,6 +7,10 @@ import {
   getMint,
   getAssociatedTokenAddressSync,
   createAssociatedTokenAccountInstruction,
+  TYPE_SIZE,
+  LENGTH_SIZE,
+  getMetadataPointerState,
+  getTokenMetadata,
   getAccount,
   createTransferCheckedWithTransferHookInstruction,
 } from "@solana/spl-token";
@@ -15,8 +19,12 @@ import {
   sendAndConfirmTransaction,
   SystemProgram,
   Transaction,
-  PublicKey,
 } from "@solana/web3.js";
+import {
+  TokenMetadata,
+  pack
+} from "@solana/spl-token-metadata";
+
 import { TransferRestrictions } from "../target/types/transfer_restrictions";
 import { assert } from "chai";
 import { topUpWallet } from "./utils";
@@ -29,6 +37,15 @@ const TRANSFER_RESTRICTION_DATA_PREFIX = "trd";
 const TRANSFER_RULE_PREFIX = "tr";
 const SECURITY_ASSOCIATED_ACCOUNT_PREFIX = "saa"; // security associated account
 const TRANSFER_RESTRICTION_HOLDER_PREFIX = "trh"; // transfer_restriction_holder
+
+enum Roles {
+  None = 0,
+  ContractAdmin = 1,
+  ReserveAdmin = 2,
+  WalletAdmin = 4,
+  TransferAdmin = 8,
+  All = 15,
+}
 
 describe("solana-security-token", () => {
   const provider = anchor.AnchorProvider.env();
@@ -139,10 +156,27 @@ describe("solana-security-token", () => {
 
   it("creates mint with transfer hook, access control and super admin role", async () => {
     // Size of Mint Account with extension
-    const extensions = [ExtensionType.TransferHook];
+    const extensions = [ExtensionType.TransferHook, ExtensionType.MetadataPointer];
     const mintLen = getMintLen(extensions);
-    const lamports =
-      await provider.connection.getMinimumBalanceForRentExemption(mintLen);
+
+    // Metadata to store in Mint Account
+    const metaData: TokenMetadata = {
+      updateAuthority: setupAccessControlArgs.authority,
+      mint: mintKeypair.publicKey,
+      name: "XYZ Security Token",
+      symbol: "XYZS",
+      uri: "https://raw.githubusercontent.com/solana-developers/opos-asset/main/assets/DeveloperPortal/metadata.json",
+      additionalMetadata: [["description", "Only Possible On Solana"]],
+    };
+
+    // Size of MetadataExtension 2 bytes for type, 2 bytes for length
+    const metadataExtension = TYPE_SIZE + LENGTH_SIZE;
+    // Size of metadata
+    const metadataLen = pack(metaData).length;
+    // Minimum lamports required for Mint Account
+    const lamports = await connection.getMinimumBalanceForRentExemption(
+      mintLen + metadataExtension + metadataLen,
+    );
 
     const balance = await provider.connection.getBalance(superAdmin.publicKey);
     const [extraMetasAccount] = anchor.web3.PublicKey.findProgramAddressSync(
@@ -153,29 +187,72 @@ describe("solana-security-token", () => {
       transferRestrictionsProgram.programId
     );
 
-    const tx = await transferRestrictionsProgram.methods
-      .initializeAccessControl({
+    const initializeAccessControlInstr = transferRestrictionsProgram.instruction.initializeAccessControl(
+      {
         decimals: setupAccessControlArgs.decimals,
         name: setupAccessControlArgs.name,
         symbol: setupAccessControlArgs.symbol,
         uri: setupAccessControlArgs.uri,
-        delegate: setupAccessControlArgs.delegate
-          ? new anchor.web3.PublicKey(setupAccessControlArgs.delegate)
-          : null,
-      })
-      .accountsStrict({
-        payer: setupAccessControlArgs.payer,
-        authority: setupAccessControlArgs.authority,
-        mint: mintKeypair.publicKey,
-        accessControl: accessControlPubkey,
-        authorityWalletRole: authorityWalletRolePubkey,
+        authority: setupAccessControlArgs.authority
+      },
+      {
+        accounts: {
+          payer: setupAccessControlArgs.payer,
+          authority: setupAccessControlArgs.authority,
+          mint: mintKeypair.publicKey,
+          accessControl: accessControlPubkey,
+          systemProgram: SystemProgram.programId,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        },
+      }
+    );
+
+    const initializeExtraAccountMetaListInstr = transferRestrictionsProgram.instruction.initializeExtraAccountMetaList({
+      accounts: {
         extraMetasAccount: extraMetasAccount,
+        securityMint: mintKeypair.publicKey,
+        payer: superAdmin.publicKey,
+        authorityWalletRole: authorityWalletRolePubkey,
+        accessControl: accessControlPubkey,
         systemProgram: SystemProgram.programId,
-        tokenProgram: TOKEN_2022_PROGRAM_ID,
-      })
-      .signers([mintKeypair, superAdmin])
-      .rpc({ commitment: confirmOptions });
-    console.log("InitializeAccessControl transaction signature", tx);
+      },
+    });
+
+    const initializeDeployerRoleInstr = transferRestrictionsProgram.instruction
+      .initializeDeployerRole({
+        accounts: {
+          payer: superAdmin.publicKey,
+          accessControl: accessControlPubkey,
+          securityToken: mintKeypair.publicKey,
+          walletRole: authorityWalletRolePubkey,
+          systemProgram: SystemProgram.programId,
+        },
+      });
+
+    // Add instructions to new transaction
+    const transaction = new Transaction().add(
+      initializeAccessControlInstr,
+      initializeDeployerRoleInstr,
+      initializeExtraAccountMetaListInstr,
+    );
+
+    try {
+      console.log('Mint Keypair', mintKeypair.publicKey.toBase58());
+      console.log('Access Control Pubkey', accessControlPubkey.toBase58());
+      console.log('Authority Wallet Role Pubkey', authorityWalletRolePubkey.toBase58());
+
+      // Send transaction
+      const transactionSignature = await sendAndConfirmTransaction(
+        connection,
+        transaction,
+        [superAdmin, mintKeypair], // Signers
+        { commitment: confirmOptions }
+      );
+      console.log("Transaction Signature", transactionSignature);
+    }
+    catch (error) {
+      console.error(error);
+    }
 
     const accessControlData =
       await transferRestrictionsProgram.account.accessControl.fetch(
@@ -188,7 +265,8 @@ describe("solana-security-token", () => {
       await transferRestrictionsProgram.account.walletRole.fetch(
         authorityWalletRolePubkey
       );
-    assert.deepEqual(walletRoleData.role, 15);
+    assert.deepEqual(walletRoleData.role, Roles.ContractAdmin);
+    assert.deepEqual(accessControlData.authority, setupAccessControlArgs.authority);
 
     let mintData = await getMint(
       connection,
@@ -201,9 +279,25 @@ describe("solana-security-token", () => {
     assert.deepEqual(mintData.decimals, decimals);
     assert.deepEqual(mintData.isInitialized, true);
     assert.deepEqual(mintData.freezeAuthority, accessControlPubkey);
+
+    // Retrieve and verify the metadata pointer state
+    const metadataPointer = getMetadataPointerState(mintData);
+    assert.deepEqual(metadataPointer.authority, accessControlPubkey)
+    assert.deepEqual(metadataPointer.metadataAddress, mintKeypair.publicKey)
+
+    // Retrieve and verify the metadata state
+    const metadata = await getTokenMetadata(
+      connection,
+      mintKeypair.publicKey, // Mint Account address
+    );
+    assert.deepEqual(metadata.mint, mintKeypair.publicKey);
+    assert.deepEqual(metadata.updateAuthority, accessControlPubkey);
+    assert.equal(metadata.name, setupAccessControlArgs.name);
+    assert.equal(metadata.symbol, setupAccessControlArgs.symbol);
+    assert.equal(metadata.uri, setupAccessControlArgs.uri);
   });
 
-  it("mints tokens to new account", async () => {
+  it("creates associated token account for user wallet", async () => {
     const transaction = new Transaction().add(
       createAssociatedTokenAccountInstruction(
         superAdmin.publicKey,
@@ -223,7 +317,54 @@ describe("solana-security-token", () => {
       "Create Associated Token Account Transaction Signature",
       txCreateAssTokenAccount
     );
+  });
 
+  it("failed to mint without ReserveAdmin role", async () => {
+    try {
+      await transferRestrictionsProgram.rpc.mintSecurities(mintAmount, {
+        accounts: {
+          authority: superAdmin.publicKey,
+          authorityWalletRole: authorityWalletRolePubkey,
+          accessControl: accessControlPubkey,
+          securityMint: mintKeypair.publicKey,
+          destinationAccount: userWalletAssociatedAccountPubkey,
+          destinationAuthority: userWalletPubkey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        },
+        signers: [superAdmin],
+        instructions: [],
+      });
+    } catch ({ error }) {
+      assert.equal(error.errorCode.number, 6001);
+      assert.equal(error.errorMessage, 'Unauthorized');
+      assert.equal(error.errorCode.code, 'Unauthorized')
+    }
+  })
+
+  it("assigns ReserveAdmin role to super admin", async () => {
+    const newRoles = Roles.ReserveAdmin | Roles.ContractAdmin;
+    const assignRoleTx = await transferRestrictionsProgram.methods
+      .updateWalletRole(newRoles)
+      .accountsStrict({
+        walletRole: authorityWalletRolePubkey,
+        authorityWalletRole: authorityWalletRolePubkey,
+        securityToken: mintKeypair.publicKey,
+        userWallet: superAdmin.publicKey,
+        payer: superAdmin.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .signers([superAdmin])
+      .rpc({ commitment: confirmOptions });
+    console.log("Assign Role Transaction Signature", assignRoleTx);
+
+    const walletRoleData =
+      await transferRestrictionsProgram.account.walletRole.fetch(
+        authorityWalletRolePubkey
+      );
+    assert.deepEqual(walletRoleData.role, newRoles);
+  });
+
+  it("mints tokens to new account", async () => {
     const mintTx = await transferRestrictionsProgram.methods
       .mintSecurities(mintAmount)
       .accountsStrict({
@@ -285,7 +426,7 @@ describe("solana-security-token", () => {
     );
   });
 
-  // === TRANSFER RESTRICTIONS SETUP ===
+  // // === TRANSFER RESTRICTIONS SETUP ===
   it("creates transfer restriction data", async () => {
     const initTransferRestrictionDataTx =
       await transferRestrictionsProgram.methods


### PR DESCRIPTION
In order to resolve issue with stack size overflow Initialization of access control instruction is splitted to 3